### PR TITLE
Jrr Category Delete Fix

### DIFF
--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -6,16 +6,20 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using TabloidMVC.Models;
+using TabloidMVC.Models.ViewModels;
 using TabloidMVC.Repositories;
 
 namespace TabloidMVC.Controllers
 {
     public class CategoryController : Controller
+   
     {
         private readonly ICategoryRepository _categoryRepo;
-        public CategoryController(ICategoryRepository categoryRepository)
+        private readonly IPostRepository _postRepository;
+        public CategoryController(ICategoryRepository categoryRepository, IPostRepository postRepository)
         {
             _categoryRepo = categoryRepository;
+            _postRepository = postRepository;
         }
         // GET: CategoryController
         public ActionResult Index()
@@ -28,11 +32,15 @@ namespace TabloidMVC.Controllers
         public ActionResult Details(int id)
         {
             Category category = _categoryRepo.GetCategoryById(id);
-            if (category == null)
+            List<Post> posts = _postRepository.GetPostsByCategoryId(category.Id);
+
+            CategoryDeleteViewModel vm = new CategoryDeleteViewModel()
             {
-                return NotFound();
-            }
-            return View(category);
+                Posts = posts,
+                Category = category
+            };
+           
+            return View(vm);
         }
 
         // GET: CategoryController/Create

--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -32,15 +32,11 @@ namespace TabloidMVC.Controllers
         public ActionResult Details(int id)
         {
             Category category = _categoryRepo.GetCategoryById(id);
-            List<Post> posts = _postRepository.GetPostsByCategoryId(category.Id);
-
-            CategoryDeleteViewModel vm = new CategoryDeleteViewModel()
+            if (category == null)
             {
-                Posts = posts,
-                Category = category
-            };
-           
-            return View(vm);
+                return NotFound();
+            }
+            return View(category);
         }
 
         // GET: CategoryController/Create
@@ -94,10 +90,20 @@ namespace TabloidMVC.Controllers
 
         // GET: CategoryController/Delete/5
         public ActionResult Delete(int id)
-        {
+        { 
             Category category = _categoryRepo.GetCategoryById(id);
-            return View(category);
+            List<Post> posts = _postRepository.GetPostsByCategoryId(category.Id);
+
+            CategoryDeleteViewModel vm = new CategoryDeleteViewModel()
+            {
+                Posts = posts,
+                Category = category
+            };
+
+            return View(vm);
         }
+
+      
 
         // POST: CategoryController/Delete/5
         [HttpPost]

--- a/TabloidMVC/Models/Category.cs
+++ b/TabloidMVC/Models/Category.cs
@@ -4,5 +4,6 @@
     {
         public int Id { get; set; }
         public string Name { get; set; }
+    
     }
 }

--- a/TabloidMVC/Models/Comment.cs
+++ b/TabloidMVC/Models/Comment.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TabloidMVC.Models
+{
+    public class Comment
+    {
+        public int Id { get; set; }
+        public string Subject { get; set; }
+        public string Content { get; set; }
+        public DateTime CreateDateTime { get; set; }
+        public int UserProfileId { get; set; }
+        public int PostId { get; set; }
+
+    }
+}

--- a/TabloidMVC/Models/ViewModels/CategoryDeleteViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/CategoryDeleteViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TabloidMVC.Models.ViewModels
+{
+    public class CategoryDeleteViewModel
+    {
+        public Category Category { get; set; }
+        public List<Post> Posts { get; set; }
+    }
+}

--- a/TabloidMVC/Repositories/IPostRepository.cs
+++ b/TabloidMVC/Repositories/IPostRepository.cs
@@ -10,6 +10,7 @@ namespace TabloidMVC.Repositories
         Post GetPublishedPostById(int id);
         Post GetUserPostById(int id, int userProfileId);
         List<Post> GetUserPostByIdList(int userId);
+        List<Post> GetPostsByCategoryId(int categoryId);
         void UpdatePost(Post post);
         void DeletePost(int id);
     }

--- a/TabloidMVC/Repositories/PostRepository.cs
+++ b/TabloidMVC/Repositories/PostRepository.cs
@@ -170,6 +170,35 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
+        public List<Post> GetPostsByCategoryId(int categoryId)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                                        SELECT Id, Title
+                                        FROM Post
+                                        WHERE CategoryId = @categoryId";
+                    cmd.Parameters.AddWithValue("@categoryId", categoryId);
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    List<Post> posts = new List<Post>();
+
+                    while (reader.Read())
+                    {
+                        Post post = new Post()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Title = reader.GetString(reader.GetOrdinal("Title"))
+                        };
+                        posts.Add(post);
+                        }
+                    reader.Close();
+                    return posts;
+                }
+            }
+        }
 
 
         public void Add(Post post)

--- a/TabloidMVC/Views/Category/Delete.cshtml
+++ b/TabloidMVC/Views/Category/Delete.cshtml
@@ -1,4 +1,4 @@
-﻿@model TabloidMVC.Models.Category
+﻿@model TabloidMVC.Models.ViewModels.CategoryDeleteViewModel
 
 @{
     ViewData["Title"] = "Delete";
@@ -6,23 +6,27 @@
 
 <h1>Delete</h1>
 
-<h3>Are you sure you want to delete @Model.Name?</h3>
-
 <div>
     <h4>Category</h4>
-    <hr />
-    <dl class="row">
-        
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Name)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Name)
-        </dd>
-    </dl>
-    
+    <span>@Model.Category.Name</span>
+</div>
+
+@if (Model.Posts.Count == 0)
+{
     <form asp-action="Delete">
         <input type="submit" value="Delete" class="btn btn-danger" /> |
         <a asp-action="Index">Back to List</a>
     </form>
-</div>
+}
+else
+{
+@foreach (Post post in Model.Posts)
+{
+    <h3>Note, you can not delete categories associated with post(s). Please remove the post(s) from this category to delete.</h3>
+
+        <h4>Associated Post(s)</h4>
+        <span>@post.Title</span>
+
+}
+}
+

--- a/TabloidMVC/Views/Category/Delete.cshtml
+++ b/TabloidMVC/Views/Category/Delete.cshtml
@@ -6,17 +6,13 @@
 
 <h1>Delete</h1>
 
-<h3>Are you sure you want to delete this?</h3>
+<h3>Are you sure you want to delete @Model.Name?</h3>
+
 <div>
     <h4>Category</h4>
     <hr />
     <dl class="row">
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Id)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Id)
-        </dd>
+        
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.Name)
         </dt>

--- a/TabloidMVC/Views/Category/Details.cshtml
+++ b/TabloidMVC/Views/Category/Details.cshtml
@@ -1,4 +1,4 @@
-﻿@model TabloidMVC.Models.ViewModels.CategoryDeleteViewModel
+﻿@model TabloidMVC.Models.Category
 
 @{
     ViewData["Title"] = "Details";
@@ -8,17 +8,18 @@
 
 <div>
     <h4>Category</h4>
-    <label>Category Name:</label>
-    <span>@Model.Category.Name</span>
+    <hr />
+    <dl class="row">
+
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Name)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Name)
+        </dd>
+    </dl>
 </div>
 <div>
-    @foreach (Post post in Model.Posts)
-    {
-        <div>
-            <label>Associated Posts:</label>
-            <span>@post.Title</span>
-        </div>
-    }
-    @Html.ActionLink("Edit", "Edit", new { id = Model.Category.Id }) |
+    @Html.ActionLink("Edit", "Edit", new { id = Model.Id }) |
     <a asp-action="Index">Back to List</a>
 </div>

--- a/TabloidMVC/Views/Category/Details.cshtml
+++ b/TabloidMVC/Views/Category/Details.cshtml
@@ -1,4 +1,4 @@
-﻿@model TabloidMVC.Models.Category
+﻿@model TabloidMVC.Models.ViewModels.CategoryDeleteViewModel
 
 @{
     ViewData["Title"] = "Details";
@@ -8,18 +8,17 @@
 
 <div>
     <h4>Category</h4>
-    <hr />
-    <dl class="row">
-       
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Name)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Name)
-        </dd>
-    </dl>
+    <label>Category Name:</label>
+    <span>@Model.Category.Name</span>
 </div>
 <div>
-    @Html.ActionLink("Edit", "Edit", new { id = Model.Id }) |
+    @foreach (Post post in Model.Posts)
+    {
+        <div>
+            <label>Associated Posts:</label>
+            <span>@post.Title</span>
+        </div>
+    }
+    @Html.ActionLink("Edit", "Edit", new { id = Model.Category.Id }) |
     <a asp-action="Index">Back to List</a>
 </div>


### PR DESCRIPTION
Changes made for ticket #11 bug fix. Previously user could not delete a category that was associated with an existing post without throwing an error. Implemented a view model and a method in the Post Repository to associate posts with categories and to display a message that would alert the user that they are unable to delete categories associated with existing posts. Users can still add, edit, delete other categories as necessary. 